### PR TITLE
Removed interactive prompt in CLI interface.

### DIFF
--- a/user_interfaces/cli.py
+++ b/user_interfaces/cli.py
@@ -160,10 +160,10 @@ class InteractiveMenu:
 
 @app.command()
 def interactive(
-    interactive: bool = typer.Option(False, prompt="Run program in interactive mode?")
+    interactive: bool = typer.Argument(True)
 ):
     """
-    Ask user if they want interactive interface or not
+    Interactive/Non interactive router.
     """
     if interactive:
         InteractiveMenu().runner()


### PR DESCRIPTION
This PR solves #36 and allows user to run interactive mode with ```python3 user_interfaces/cli.py interactive```