### PR TITLE
Added fixes for blender benchmark executable download.

### DIFF
--- a/benchmarks/blender_benchmark/implementation.py
+++ b/benchmarks/blender_benchmark/implementation.py
@@ -14,7 +14,7 @@ class BlenderBenchmark(BenchmarkWrapper):
     def __init__(self):
         self._settings = {}
         self.filePath = os.path.dirname(__file__)
-        self.baseCommand = "benchmark-launcher-cli"
+        self.baseCommand = "bin/benchmark-launcher-cli"
 
     def setSettings(self, settings_file):
         self._settings = json.load(open(settings_file, "r"))

--- a/benchmarks/blender_benchmark/setup.py
+++ b/benchmarks/blender_benchmark/setup.py
@@ -6,7 +6,10 @@ import zipfile
 
 
 if __name__ == "__main__":
-    filePath = os.path.dirname(__file__)
+    currPath = os.path.dirname(__file__)
+    if not os.path.exists(os.path.join(currPath, "bin")):
+        os.mkdir(os.path.join(currPath, "bin"))
+    filePath = os.path.join(os.path.dirname(__file__), "bin")
     system = platform.system().lower()
     if system == "linux":
         url = "https://download.blender.org/release/BlenderBenchmark2.0/launcher/benchmark-launcher-cli-2.0.5-linux.tar.gz"


### PR DESCRIPTION
This PR corrects the path set for downloading the benchmark executables in ``` /bin ```.
This solves #22 also is the reason for error seen in #40 . 