### PR TITLE
Introducing direct executable to user CLI

### DIFF
--- a/common/phoronix_parser.py
+++ b/common/phoronix_parser.py
@@ -321,4 +321,3 @@ if __name__ == "__main__":
 
     phoronix_init()
     # phoronix_install("astcenc", "1.1.0")
- 


### PR DESCRIPTION
Simply a symlink, but that works. Fixes #118.

Enables using the CLI via `o4bc-bench [...]`.