### PR TITLE
Fixing progressbar

### DIFF
--- a/common/phoronix_parser.py
+++ b/common/phoronix_parser.py
@@ -36,7 +36,7 @@ class ProgressBar():
 
     def __call__(self, block_num, block_size, total_size):
         if not self.pbar:
-            self.pbar = progressbar.ProgressBar(maxval=total_size or None)
+            self.pbar = progressbar.ProgressBar(maxval=total_size if total_size > 0 else 0)
             self.pbar.start()
 
         downloaded = block_num * block_size


### PR DESCRIPTION
Fixes randomly occurring CI error due to wrong progress bar max value.
Fixes #124 . Apparently sometimes (read: when the file is missing) the max value is set to negative value leading to an issue.