### PR TITLE
Adding benchmark/*/bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ benchmarks/blender_benchmark/benchmark-launcher-cli
 logs/*
 common/phoronix-benchs/
 benchmarks/phoronix-*
-benchmark/*/bin
+benchmarks/*/bin


### PR DESCRIPTION
The folder bin inside every benchmark will be ignore by git.