### PR TITLE
Adding benchmarks/*/bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ benchmarks/blender_benchmark/benchmark-launcher-cli
 logs/*
 common/phoronix-benchs/
 benchmarks/phoronix-*
+benchmarks/*/bin


### PR DESCRIPTION
Said to .gitignore to ignore the bin folder inside every benchmark.