### PR TITLE
Define clang-tidy and clang-format configurations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+BasedOnStyle: Google
+Standard: Cpp11
+SortIncludes: true
+PointerAlignment: Left
+IncludeBlocks: Regroup

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: >
+  -*,
+  bugprone-*,
+
+  clang-diagnostic-*,
+
+  google-*,
+
+  misc-*,
+
+  modernize-*,
+  -modernize-use-trailing-return-type,
+
+  performance-*,
+  readability-*,
+  -readability-implicit-bool-conversion
+
+FormatStyle: file


### PR DESCRIPTION
The `.clang-format` is based on Google style guide with some additions
such as specifying the c++ standard (c++11).

The `.clang-tidy` disables all the default checks and enables a sensible
set of them, it also specifies to use the defined `.clang-format` to
format fixes applied automatically.
