### PR TITLE
Fix benchmark suite json schema

### DIFF
--- a/openforbc_benchmark/jsonschema/benchmark_suite.schema.json
+++ b/openforbc_benchmark/jsonschema/benchmark_suite.schema.json
@@ -5,24 +5,31 @@
   "description": "A benchmark suite JSON definition schema",
   "$defs": {
     "benchmark_run": {
-      "benchmark_folder": {
-        "description": "The folder containing the benchmark",
-        "type": "string"
-      },
-      "presets": {
-        "description": "The presets (or a single preset) to be run",
-        "oneOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {
+      "properties": {
+        "benchmark_folder": {
+          "description": "The folder containing the benchmark",
+          "type": "string"
+        },
+        "presets": {
+          "description": "The presets (or a single preset) to be run",
+          "oneOf": [
+            {
               "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
-          }
-        ]
-      }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "benchmark_folder",
+        "presets"
+      ]
     }
   },
   "type": "object",


### PR DESCRIPTION
The `benchmark_run` type was defined incorrectly (`properties` field was
missing) and required fields were not specified. `additionalProperties` is now
set to `false` so that adding unrecognized properties to a suite definition
will invalidate it.
