### PR TITLE
Add `default_preset` field to benchmark definition

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -76,6 +76,7 @@ Here's an example of a benchmark definition:
 | ----------------- | ----------------- | -------- |
 | `name`            | `string`          | x        |
 | `description`     | `string`          | x        |
+| `default_preset`  | `string`          | x        |
 | `setup_command`   | *commands*        |          |
 | `run_command`     | *commands*        | x        |
 | `cleanup_command` | *commands*        |          |
@@ -84,6 +85,9 @@ Here's an example of a benchmark definition:
 
 All the metadata fields are __required__: you need to specify the benchmark's
 *name* and *description*.
+
+The `default_preset` field (**required**) is the name of the default preset: the
+referenced preset **must** be present in the `presets` folder.
 
 ##### Commands
 
@@ -138,8 +142,11 @@ represented by a JSON file (its
 [schema](../josnschema/benchmark_preset.schema.json) is stored in the
 *jsonschema* folder in this repository).
 
-You can define more than one preset and select the one you want to run the
+You can define more than one preset and select the ones you want to run the
 benchmark with later when running the benchmark. 
+
+The default preset is specified in the benchmark's definition (field
+`default_preset`)  and must be defined.
 
 #### Benchmark preset schema
 

--- a/jsonschema/benchmark.schema.json
+++ b/jsonschema/benchmark.schema.json
@@ -1,43 +1,66 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/openforbc.benchmark.schema.json",
-
   "title": "Open-ForBC benchmark schema",
   "description": "A benchmark JSON definition schema",
-
   "$defs": {
     "command": {
-      "oneOf": [ { "type": "string" }, {
-        "type": "object",
-        "properties": {
-          "path": { "type": "string" },
-          "env": {
-            "type": "object",
-            "additionalProperties": { "type": "string" }
-          },
-          "workdir": { "type": "string" }
+      "oneOf": [
+        {
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": [ "path" ]
-      } ]
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "workdir": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ]
+        }
+      ]
     },
     "commands": {
       "oneOf": [
-        { "$ref": "#/$defs/command" },
-        { "type": "array", "items": { "$ref": "#/$defs/command" } }
+        {
+          "$ref": "#/$defs/command"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/command"
+          }
+        }
       ]
     },
     "match": {
       "type": "object",
       "properties": {
-        "regex": { "type": "string" },
-        "file": { "type": "string" }
+        "regex": {
+          "type": "string"
+        },
+        "file": {
+          "type": "string"
+        }
       },
       "additionalProperties": false,
-      "required": [ "regex" ]
+      "required": [
+        "regex"
+      ]
     }
   },
-
   "type": "object",
   "properties": {
     "name": {
@@ -46,6 +69,10 @@
     },
     "description": {
       "description": "A brief description of the benchmark",
+      "type": "string"
+    },
+    "default_preset": {
+      "description": "The benchmark's default preset",
       "type": "string"
     },
     "setup_command": {
@@ -63,8 +90,15 @@
     "stats": {
       "description": "Command to be executed in order to fetch stats or a set of stats",
       "oneOf": [
-        { "type": "string" },
-        { "type": "object", "additionalProperties": { "$ref": "#/$defs/match" } }
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/match"
+          }
+        }
       ]
     },
     "virtualenv": {
@@ -73,5 +107,11 @@
     }
   },
   "additionalProperties": false,
-  "required": [ "name", "description", "run_command", "stats" ]
+  "required": [
+    "name",
+    "description",
+    "default_preset",
+    "run_command",
+    "stats"
+  ]
 }


### PR DESCRIPTION
The default preset will be run when no presets are specified and will be
selected by default when using the interactive cli app.
