### PR TITLE
Add `test_command` field to benchmark's definition

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -1,4 +1,4 @@
-name: Benchmarks run test
+name: Benchmarks tests
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - "benchmarks/**"
 
 jobs:
-  benchmarks_run_test:
+  benchmarks_tests:
     runs-on: ${{ matrix.image }}
 
     strategy:
@@ -65,7 +65,7 @@ jobs:
         with:
           files: ^benchmarks/
 
-      - name: Run modified benchmarks
+      - name: Run modified benchmarks' tests
         run: |
           benchmarks=""
 
@@ -75,6 +75,10 @@ jobs:
 
           for benchmark in $(printf $benchmarks | uniq); do
             echo "::group::$benchmark"
+            echo "Running benchmark tests"
+            poetry run o4bc-bench benchmark test $benchmark
+            echo
+            echo "Running benchmark"
             poetry run o4bc-bench benchmark run $benchmark
             echo "::endgroup"
           done

--- a/benchmarks/dummy_benchmark/benchmark.json
+++ b/benchmarks/dummy_benchmark/benchmark.json
@@ -17,6 +17,7 @@
       "daw"
     ]
   },
+  "test_command": "true",
   "stats": {
     "data_1": {
       "regex": "data: (\\d+)"

--- a/benchmarks/dummy_py_benchmark/benchmark.json
+++ b/benchmarks/dummy_py_benchmark/benchmark.json
@@ -17,6 +17,7 @@
       "daw"
     ]
   },
+  "test_command": "true",
   "stats": {
     "data_1": {
       "regex": "data: (\\d+)"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -118,6 +118,7 @@ Here's an example of a benchmark definition:
 | `setup_command`   | *commands*           |          |
 | `run_command`     | *commands*           | x        |
 | `cleanup_command` | *commands*           |          |
+| `test_command`    | *commands*           | x        |
 | `stats`           | *command*`\|`*match* | x        |
 | `virtualenv`      | `boolean`            |          |
 
@@ -129,11 +130,13 @@ referenced preset **must** be present in the `presets` folder.
 
 ##### Commands
 
-There are three main commands used to interface with the benchmark: the
+There are four main commands used to interface with the benchmark: the
 `setup_command` is run before any other command and should be used, for
 instance, to install benchmark dependencies or build its binary, the
 `run_command` (__required__) is the actual benchmark command, and
 `cleanup_command` is used after the benchmark is no longer needed to cleanup.
+The `test_command` should be a list of commands (or a single one) which return
+zero exit code if the tests pass.
 
 Every *command* field can be a single instance or an array of `command` type.
 The `command` type can be a *string* (the path of the executable to be run) or

--- a/openforbc_benchmark/benchmark.py
+++ b/openforbc_benchmark/benchmark.py
@@ -43,6 +43,7 @@ class Benchmark(BenchmarkDefinition):
         setup_commands: "Optional[List[CommandInfo]]",
         run_commands: "List[CommandInfo]",
         cleanup_commands: "Optional[List[CommandInfo]]",
+        test_commands: "List[CommandInfo]",
         stats: "Union[CommandInfo, Dict[str, StatMatchInfo]]",
         virtualenv: bool,
         dir: str,
@@ -55,6 +56,7 @@ class Benchmark(BenchmarkDefinition):
             setup_commands,
             run_commands,
             cleanup_commands,
+            test_commands,
             stats,
             virtualenv,
         )
@@ -74,6 +76,7 @@ class Benchmark(BenchmarkDefinition):
             self.setup_commands,
             self.run_commands,
             self.cleanup_commands,
+            self.test_commands,
             self.stats,
             self.virtualenv,
         )
@@ -258,6 +261,11 @@ class BenchmarkRun:
         """
         for preset in self.presets:
             yield preset, self._run_preset(preset)
+
+    def test(self) -> "Iterator[Runnable]":
+        """Get the tasks for this benchmark run's test commands."""
+        for command in self.benchmark.test_commands:
+            yield self._add_context(command.into_runnable())
 
     def get_stats(self, stdout: "Union[str, TextIO]") -> "Dict[str, Union[int, float]]":
         from json import load, loads

--- a/openforbc_benchmark/json.py
+++ b/openforbc_benchmark/json.py
@@ -63,6 +63,7 @@ class BenchmarkDefinition(Serializable["BenchmarkDefinition"]):
         setup_commands: "Optional[List[CommandInfo]]",
         run_commands: "List[CommandInfo]",
         cleanup_commands: "Optional[List[CommandInfo]]",
+        test_commands: "List[CommandInfo]",
         stats: "Union[CommandInfo, Dict[str, StatMatchInfo]]",
         virtualenv: bool,
     ) -> None:
@@ -73,6 +74,7 @@ class BenchmarkDefinition(Serializable["BenchmarkDefinition"]):
         self.setup_commands = setup_commands
         self.run_commands = run_commands
         self.cleanup_commands = cleanup_commands
+        self.test_commands = test_commands
         self.stats = stats
         self.virtualenv = virtualenv
 
@@ -80,36 +82,29 @@ class BenchmarkDefinition(Serializable["BenchmarkDefinition"]):
     def deserialize(self_class, json: "Any") -> "BenchmarkDefinition":
         self_class.validate(json)
 
-        setup_commands = (
-            CommandInfo.deserialize_commands(json["setup_command"])
-            if "setup_command" in json
-            else None
-        )
-
-        run_commands = CommandInfo.deserialize_commands(json["run_command"])
-
-        cleanup_commands = (
-            CommandInfo.deserialize_commands(json["cleanup_command"])
-            if "cleanup_command" in json
-            else None
-        )
-
-        stats: "Union[CommandInfo , Dict[str, StatMatchInfo]]" = (
-            CommandInfo.deserialize(json["stats"])
-            if isinstance(json["stats"], str) or "command" in json["stats"]
-            else {
-                str(k): StatMatchInfo.deserialize(v) for k, v in json["stats"].items()
-            }
-        )
-
         return self_class(
             json["name"],
             json["description"],
             json["default_preset"],
-            setup_commands,
-            run_commands,
-            cleanup_commands,
-            stats,
+            # setup_command
+            CommandInfo.deserialize_commands(json["setup_command"])
+            if "setup_command" in json
+            else None,
+            # run_command
+            CommandInfo.deserialize_commands(json["run_command"]),
+            # cleanup_command
+            CommandInfo.deserialize_commands(json["cleanup_command"])
+            if "cleanup_command" in json
+            else None,
+            # test_command
+            CommandInfo.deserialize_commands(json["test_command"]),
+            # stats
+            CommandInfo.deserialize(json["stats"])
+            if isinstance(json["stats"], str) or "command" in json["stats"]
+            else {
+                str(k): StatMatchInfo.deserialize(v) for k, v in json["stats"].items()
+            },
+            # virtualenv
             json.get("virtualenv", False),
         )
 

--- a/openforbc_benchmark/jsonschema/benchmark.schema.json
+++ b/openforbc_benchmark/jsonschema/benchmark.schema.json
@@ -97,6 +97,10 @@
       "description": "Command to be executed in order to do cleanup after running the benchmark",
       "$ref": "#/$defs/commands"
     },
+    "test_command": {
+      "description": "Command (or commands) to be executed in order to tests the benchmark",
+      "$ref": "#/$defs/commands"
+    },
     "stats": {
       "description": "Command to be executed in order to fetch stats or a set of stats",
       "oneOf": [
@@ -122,6 +126,7 @@
     "description",
     "default_preset",
     "run_command",
+    "test_command",
     "stats"
   ]
 }

--- a/tests/cli/test_benchmark.py
+++ b/tests/cli/test_benchmark.py
@@ -67,3 +67,9 @@ def test_benchmark_run() -> None:
     assert result.exit_code == 0
     assert "---" in result.stdout
     assert "135246" in result.stdout
+
+
+def test_benchmark_test() -> None:
+    result = runner.invoke(app, ["test", "dummy_benchmark"])
+    assert result.exit_code == 0
+    assert "true" in result.stdout

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -52,6 +52,7 @@ def test_benchmark_from_definition() -> None:
             None,
             [CommandInfo("echo hello")],
             None,
+            [CommandInfo("true")],
             {"stat_1": StatMatchInfo("dummy_regex")},
             False,
         ),
@@ -62,6 +63,7 @@ def test_benchmark_from_definition() -> None:
     assert benchmark.description == "description"
     assert benchmark.default_preset == "preset"
     assert benchmark.run_commands[0].command == ["echo", "hello"]
+    assert benchmark.test_commands[0].command == ["true"]
     assert isinstance(benchmark.stats, dict)
     assert benchmark.stats["stat_1"].regex == "dummy_regex"
     assert not benchmark.virtualenv
@@ -153,6 +155,22 @@ def test_benchmark_run_cleanup() -> None:
     tasks = list(run.cleanup())
     assert all(task.env is None or "VIRTUALENV" not in task.env for task in tasks)
     assert tasks[0].args == ["echo", "daw"]
+
+
+def test_benchmark_run_test() -> None:
+    run = get_dummy_run()
+    assert list(run.setup())  # "run" setup tasks
+    tasks = list(run.test())
+    assert tasks[0].args == ["true"]
+
+
+def test_benchmark_run_py_test() -> None:
+    run = get_dummy_py_run()
+    assert list(run.setup())  # "run" setup tasks
+    tasks = list(run.test())
+    assert all(task.env is not None and "VIRTUALENV" in task.env for task in tasks)
+    print(tasks)
+    assert tasks[0].args == ["true"]
 
 
 def test_benchmark_run_py_cleanup() -> None:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -32,6 +32,7 @@ def test_benchmark_deserialization() -> None:
             "daw"
             ]
         },
+        "test_command": "true",
         "stats": {
             "data_1": {
             "regex": "data: (\\d+)",
@@ -50,6 +51,7 @@ def test_benchmark_deserialization() -> None:
     assert benchmark.setup_commands[0].env["INSTALL"] == "1"
     assert benchmark.setup_commands[0].env["ENVIRONMENT"] == "production"
     assert benchmark.setup_commands[0].workdir == "presets"
+    assert benchmark.test_commands[0].command == ["true"]
     assert benchmark.cleanup_commands is not None
     assert benchmark.cleanup_commands[0].command == ["echo", "daw"]
     assert isinstance(benchmark.stats, dict)


### PR DESCRIPTION
This will allow benchmarks to define their own tests, which can be run in the
CI pipeline.

Tests will be considered passing if all the specified commands return a zero
exit code.
