### PR TITLE
Fix virtualenv environment

### DIFF
--- a/openforbc_benchmark/benchmark.py
+++ b/openforbc_benchmark/benchmark.py
@@ -361,7 +361,7 @@ class BenchmarkRun:
         run_env = runnable.env.copy() if runnable.env is not None else None
         if self._virtualenv is not None:
             new_env = {
-                "VIRTUALENV": self._virtualenv,
+                "VIRTUAL_ENV": self._virtualenv,
             }
 
             if run_env is not None:

--- a/openforbc_benchmark/utils.py
+++ b/openforbc_benchmark/utils.py
@@ -33,17 +33,21 @@ class Runnable:
     def __repr__(self) -> str:
         venv = False
 
-        if self.env and "VIRTUALENV" in self.env:
+        if self.env and "VIRTUAL_ENV" in self.env:
             venv = True
-            virtualenv_path = self.env.pop("VIRTUALENV")
-            self.path.remove(f"{virtualenv_path}/bin")
+            virtualenv_path = self.env["VIRTUAL_ENV"]
 
         env = (
             None
             if self.env is None
-            else " ".join(f"{quote(k)}={quote(v)}" for k, v in self.env.items())
+            else " ".join(
+                f"{quote(k)}={quote(v)}"
+                for k, v in self.env.items()
+                if k != "VIRTUAL_ENV"
+            )
         )
-        path = None if not self.path else f"PATH+={quote(':'.join(self.path))}"
+        clean_path = [x for x in self.path if (not venv) or virtualenv_path not in x]
+        path = None if not clean_path else f"PATH+={quote(':'.join(clean_path))}"
         return (
             f"{'(venv) ' if venv else ''}$ {path + ' ' if path else ''}"
             f"{env + ' ' if env else ''}{self.command_str()}"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -122,7 +122,7 @@ def test_benchmark_run_py_setup() -> None:
     setup_tasks = list(run.setup())
     assert setup_tasks[0].args == ["python3", "-m", "venv", ".venv"]
     assert all(
-        task.env is not None and "VIRTUALENV" in task.env for task in setup_tasks[1:]
+        task.env is not None and "VIRTUAL_ENV" in task.env for task in setup_tasks[1:]
     )
     assert setup_tasks[1].args == ["echo", "hello world"]
 
@@ -133,7 +133,7 @@ def test_benchmark_run_run() -> None:
     presets = list(run.run())
     assert presets[0][0].name == "preset1"
     tasks = list(presets[0][1])
-    assert all(task.env is None or "VIRTUALENV" not in task.env for task in tasks)
+    assert all(task.env is None or "VIRTUAL_ENV" not in task.env for task in tasks)
     assert tasks[0].args == ["echo", "setup.sh", "--config=preset1.conf"]
     assert tasks[1].args == ["echo", "data:", "135246", "--config=preset1.conf"]
 
@@ -144,7 +144,7 @@ def test_benchmark_run_py_run() -> None:
     presets = list(run.run())
     assert presets[0][0].name == "preset1"
     tasks = list(presets[0][1])
-    assert all(task.env is not None and "VIRTUALENV" in task.env for task in tasks)
+    assert all(task.env is not None and "VIRTUAL_ENV" in task.env for task in tasks)
     assert tasks[0].args == ["echo", "setup.sh", "--config=preset1.conf"]
     assert tasks[1].args == ["echo", "data:", "135246", "--config=preset1.conf"]
 
@@ -153,7 +153,7 @@ def test_benchmark_run_cleanup() -> None:
     run = get_dummy_run()
     assert list(run.setup())  # "run" setup tasks
     tasks = list(run.cleanup())
-    assert all(task.env is None or "VIRTUALENV" not in task.env for task in tasks)
+    assert all(task.env is None or "VIRTUAL_ENV" not in task.env for task in tasks)
     assert tasks[0].args == ["echo", "daw"]
 
 
@@ -168,7 +168,7 @@ def test_benchmark_run_py_test() -> None:
     run = get_dummy_py_run()
     assert list(run.setup())  # "run" setup tasks
     tasks = list(run.test())
-    assert all(task.env is not None and "VIRTUALENV" in task.env for task in tasks)
+    assert all(task.env is not None and "VIRTUAL_ENV" in task.env for task in tasks)
     print(tasks)
     assert tasks[0].args == ["true"]
 
@@ -177,7 +177,7 @@ def test_benchmark_run_py_cleanup() -> None:
     run = get_dummy_py_run()
     assert list(run.setup())  # "run" setup tasks
     tasks = list(run.cleanup())
-    assert all(task.env is not None and "VIRTUALENV" in task.env for task in tasks)
+    assert all(task.env is not None and "VIRTUAL_ENV" in task.env for task in tasks)
     assert tasks[0].args == ["echo", "daw"]
 
 


### PR DESCRIPTION
The `__repr__` method of `Runnable` broke virtualenvs by modifying the
environment. The old behaviour is now replaced.

Closes #169
