### PR TITLE
Make benchmarks fail when stats match fails

### DIFF
--- a/openforbc_benchmark/benchmark.py
+++ b/openforbc_benchmark/benchmark.py
@@ -26,10 +26,18 @@ class BenchmarkPresetNotFound(Exception):
     pass
 
 
-class BenchmarkStatsDecodeError(Exception):
+class BenchmarkStatsError(Exception):
+    pass
+
+
+class BenchmarkStatsDecodeError(BenchmarkStatsError):
     def __init__(self, message: str, output: str) -> None:
         super().__init__(message)
         self.output = output
+
+
+class BenchmarkStatsMatchError(BenchmarkStatsError):
+    pass
 
 
 class Benchmark(BenchmarkDefinition):
@@ -330,6 +338,11 @@ class BenchmarkRun:
                     number = m.group(1)
                     stats[name] = float(number) if "." in number else int(number)
                     break
+
+            if name not in stats:
+                raise BenchmarkStatsMatchError(
+                    f'No match for stat "{name}" in benchmark output'
+                )
 
             if match.file is not None and isinstance(file, TextIO):
                 file.close()

--- a/openforbc_benchmark/cli/benchmark.py
+++ b/openforbc_benchmark/cli/benchmark.py
@@ -19,6 +19,7 @@ from yaspin.core import Yaspin
 from openforbc_benchmark.benchmark import (
     BenchmarkPresetNotFound,
     BenchmarkStatsDecodeError,
+    BenchmarkStatsMatchError,
     Preset,
     find_benchmark,
     get_benchmarks,
@@ -44,7 +45,7 @@ class BenchmarkTaskFailed(BenchmarkRunException):
     pass
 
 
-class BenchmarkStatsError(BenchmarkRunException):
+class BenchmarkRunStatsError(BenchmarkRunException):
     """Stats decode failed."""
 
     pass
@@ -128,13 +129,20 @@ class CliBenchmarkRun:
                         next(output)
                         self.stats[preset.name] = self.benchmark_run.get_stats(output)
             except BenchmarkStatsDecodeError as e:
-                self._log("WARNING: stats script output:", err=True)
+                self._log("ERROR: stats script output:", err=True)
                 self._log(e.output.rstrip(), err=True)
                 self._fail(
-                    BenchmarkStatsError(
+                    BenchmarkRunStatsError(
                         f'"{benchmark_id}" preset "{preset.name}" stats decode '
                         f"failed: {e}"
                     ),
+                )
+            except BenchmarkStatsMatchError as e:
+                self._fail(
+                    BenchmarkRunStatsError(
+                        f'"{benchmark_id}" preset "{preset.name}" stats match failed: '
+                        f"{e}"
+                    )
                 )
 
     def _run_setup(self) -> None:


### PR DESCRIPTION
Benchmarks will now fail if any stat's regex will not match a line in
the benchmark output.
