### PR TITLE
Run clang-tidy only when c/c++ source modified

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,29 @@
+name: Project tests
+
+on:
+  pull_request:
+    paths:
+      - "**/*.c"
+      - "**/*.cpp"
+      - "**/*.h"
+      - "**/*.hpp"
+
+jobs:
+  lint_c_cpp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run clang-tidy
+        uses: shenxianpeng/cpp-linter-action@master
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: file
+          tidy-checks: ""
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: |
+          echo "Some files failed the linting checks!"
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,25 +14,6 @@ on:
       - "**"
 
 jobs:
-  lint_c_cpp:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Run clang-tidy
-        uses: shenxianpeng/cpp-linter-action@master
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: file
-          tidy-checks: ""
-      - name: Fail fast?!
-        if: steps.linter.outputs.checks-failed > 0
-        run: |
-          echo "Some files failed the linting checks!"
-          exit 1
-
   test:
     runs-on: ${{ matrix.image }}
     strategy:


### PR DESCRIPTION
- Moved clang-tidy job to a separate workflow, which runs only when
  `.c/.cpp/.h/.hpp` files are modified
    
Fixes #191