### PR TITLE
Fix realtime benchmarks stats

### DIFF
--- a/benchmarks/CIFAR_realtime_benchmark/CIFAR_realtime.py
+++ b/benchmarks/CIFAR_realtime_benchmark/CIFAR_realtime.py
@@ -15,70 +15,24 @@
 
 import time
 import sys
-from datetime import datetime
 import argparse
-try:
-    import nvidia_smi
-except ModuleNotFoundError:
-    print("nvidia-smi has not been found. GPU support is excluded.")
-    pass
-import GPUtil
+
 import tensorflow as tf
 import tensorflow.keras as keras
 import numpy as np
 
 
-"""
-Global variables definition
-"""
+# Global variables definition
 batch_size = 1
 n_epochs = 10
 n_epochs_training = 10
 n_of_class = 10
 N = 150
 teacher_size = 8
-gpu_performance_sampling_time = 1
-keep_running = True
-
-
-class GPUstatistics(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs load
-    """
-
-    def on_train_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_predict_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
 
 
 class TimeHistory(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs compute time
-    """
+    """A set of custom Keras callbacks to monitor Nvidia GPUs compute time."""
 
     def on_train_begin(self, logs={}):
         self.batch_times = []
@@ -124,11 +78,11 @@ class TimeHistory(keras.callbacks.Callback):
 
 
 def load_CIFAR_data():
-    """
-    Loading and shaping the standard CIFAR dataset
-    """
-    (train_images, train_labels), (test_images,
-                                   test_labels) = keras.datasets.cifar10.load_data()
+    """Load and reshape the standard CIFAR dataset."""
+    (train_images, train_labels), (
+        test_images,
+        test_labels,
+    ) = keras.datasets.cifar10.load_data()
 
     # Normalize pixel values to be between 0 and 1
     train_images, test_images = train_images / 255.0, test_images / 255.0
@@ -138,123 +92,122 @@ def load_CIFAR_data():
 
 def create_CIFAR_model():
     model = keras.models.Sequential()
-    model.add(keras.layers.Conv2D(32, (3, 3), activation='relu',
-                                  input_shape=(32, 32, 3)))
+    model.add(
+        keras.layers.Conv2D(32, (3, 3), activation="relu", input_shape=(32, 32, 3))
+    )
     model.add(keras.layers.MaxPooling2D((2, 2)))
-    model.add(keras.layers.Conv2D(64, (3, 3), activation='relu'))
+    model.add(keras.layers.Conv2D(64, (3, 3), activation="relu"))
     model.add(keras.layers.MaxPooling2D((2, 2)))
-    model.add(keras.layers.Conv2D(64, (3, 3), activation='relu'))
+    model.add(keras.layers.Conv2D(64, (3, 3), activation="relu"))
     model.add(keras.layers.Flatten())
-    model.add(keras.layers.Dense(64, activation='relu'))
+    model.add(keras.layers.Dense(64, activation="relu"))
     model.add(keras.layers.Dense(10))
-    model.compile(optimizer='adam',
-                  loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-                  metrics=['accuracy'])
+    model.compile(
+        optimizer="adam",
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=["accuracy"],
+    )
 
     return model
 
 
+def gen_stats_file_name(prefix):
+    """Generate stats file name with prefix."""
+    from time import strftime
+
+    return f'stats_file_{prefix}_{strftime("%Y-%m-%d_%H-%M-%S")}.txt'
+
+
 def training_benchmark(batch_size):
     """
-    Training benchmark evaluating number of training inputs processed per second
+    Perform training benchmark.
+
+    Evaluates number of training inputs processed per second.
     """
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_training"+dt_string+".txt", 'w')
-
     (train_images, train_labels), (_, _) = load_CIFAR_data()
-
     model = create_CIFAR_model()
 
     time_callback = TimeHistory()
-    model.fit(train_images, train_labels,
-              epochs=n_epochs_training,
-              callbacks=[time_callback],
-              batch_size=batch_size,
-              verbose=1)
+    model.fit(
+        train_images,
+        train_labels,
+        epochs=n_epochs_training,
+        callbacks=[time_callback],
+        batch_size=batch_size,
+        verbose=1,
+    )
 
-    training_time = sum(time_callback.batch_times)  # total time
-    time_per_epoch = training_time / n_epochs_training
-    time_per_batch = time_per_epoch / (len(train_images)//batch_size)  # time per batch
-    time_per_sample = time_per_epoch / len(train_images)  # time per sample
-    training_sample_per_second = 1./time_per_sample  # sample per seconds
+    with open(gen_stats_file_name("training"), "w") as stats_file:
+        for batch_time in time_callback.batch_times:
+            stats_file.write(f"{batch_time}\n")
 
-    L = [str(training_time), ',', str(time_per_batch), ',', str(time_per_sample),
-         ',', str(training_sample_per_second)]
-    stats_file.writelines(L)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-    stats_file.close()
+    total_time = sum(time_callback.batch_times)
+
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / n_epochs_training / len(train_images)}"
+    )
 
 
 def inference_benchmark(iteration_limit=None):
     """
-    Inference benchmark evaluating number of Out-of-Sample inputs processed per second
-    """
-    global keep_running
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_inference"+dt_string+".txt", 'w')
+    Perform inference benchmark.
 
+    Evaluates number of Out-of-Sample inputs processed per second.
+    """
     (train_images, train_labels), (test_images, _) = load_CIFAR_data()
-
-    """
-    Training the model without measuring its performances to prepare for inference
-    """
     model = create_CIFAR_model()
 
+    # Train the model without measuring its performance to prepare for inference
     model.fit(train_images, train_labels, epochs=n_epochs, verbose=0)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-
-    """
-    Performing inference on Out-of-Sample multiple times to obtain average performance
-    """
-    sample_count = 0
-    total_time = 0
-
+    # Perform inference on Out-of-Sample multiple times to obtain average performance
     n_iterations = 0
-
-    while(keep_running):
-        print(f"Iteration {n_iterations}")
-        L = []
-        for IMG in test_images:  # online prediction (one sample at time)
-            try:
-                IMG = np.expand_dims(IMG, 0)
-                start_time = time.time()
-                _ = model(IMG)
-                end_time = time.time() - start_time
-                total_time += end_time
-                sample_count += 1
-                latency = total_time/sample_count
-                throughput = sample_count/total_time
-                L = [str(end_time), ',', str(sample_count), ',', str(
-                    latency), ',', str(throughput), ',', str(total_time)]
-                stats_file.writelines(L)
-                stats_file.writelines('\n')
-            except KeyboardInterrupt:
-                keep_running = False
-                break
-        n_iterations += 1
-        if iteration_limit:
-            if n_iterations+1 > iteration_limit:
+    keep_running = True
+    total_time = 0.0
+    with open(gen_stats_file_name("inference"), "w") as stats_file:
+        while keep_running:
+            print(f"Iteration {n_iterations}")
+            for batch in test_images:  # online prediction (one sample at time)
+                try:
+                    for DS in batch[0]:
+                        DS = np.expand_dims(DS, 0)
+                        start_time = time.time()
+                        _ = model(DS)
+                        sample_time = time.time() - start_time
+                        total_time += sample_time
+                        stats_file.write(f"{sample_time}\n")
+                        stats_file.flush()
+                except KeyboardInterrupt:
+                    keep_running = False
+                    break
+            n_iterations += 1
+            if iteration_limit and n_iterations + 1 > iteration_limit:
                 break
 
-    print('INFERENCE COMPLETED!')
-    stats_file.close()
+    print("INFERENCE COMPLETED!")
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / (len(test_images) * n_iterations)}"
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML CIFAR benchmark")
-    parser.add_argument("device_type",
-                        choices=["gpu", "cpu"],
-                        default="gpu")
-    parser.add_argument("mode",
-                        choices=["training", "inference"],
-                        default="inference")
-    parser.add_argument("-g", "--gpu_index", default=0, nargs='?')
-    parser.add_argument("-n", "--n_epochs_training", default=10, nargs='?', type=int)
-    parser.add_argument("-t", "--test_mode", action='store_true')
-    parser.add_argument("-l", "--iteration_limit",
-                        help="Maximum number of inference iterations", type=int)
+    parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
+    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
+    parser.add_argument("-n", "--n_epochs_training", default=10, nargs="?", type=int)
+    parser.add_argument("-t", "--test_mode", action="store_true")
+    parser.add_argument(
+        "-l",
+        "--iteration_limit",
+        help="Maximum number of inference iterations",
+        type=int,
+    )
 
     args = parser.parse_args()
     dev = args.device_type
@@ -262,27 +215,20 @@ if __name__ == "__main__":
     gpu_index = args.gpu_index
     n_epochs_training = args.n_epochs_training
 
-    """
-    SET DEVICE
-    """
-    if dev == 'cpu':
-        de = '/cpu:0'
-    elif dev == 'gpu':
-        """
-        Checking GPU availability
-        """
-        if tf.config.list_physical_devices('GPU') == 0:
+    # SET DEVICE
+    if dev == "cpu":
+        de = "/cpu:0"
+    elif dev == "gpu":
+        # Check GPU availability
+        if tf.config.list_physical_devices("GPU") == 0:
             print("GPU unavailable. Aborting.")
             sys.exit(0)
 
-        """
-        Telling to the used GPU to automatically increase the amount of used memory
-        """
-        GPUs = GPUtil.getGPUs()
-        gpus = tf.config.list_physical_devices('GPU')
+        gpus = tf.config.list_physical_devices("GPU")
 
         if gpus:
-            if len(gpus) >= gpu_index+1:
+            if len(gpus) >= gpu_index + 1:
+                # Use dynamic GPU memory allocation
                 tf.config.experimental.set_memory_growth(gpus[gpu_index], True)
             else:
                 print(f"GPU {gpu_index} not found. Aborting.")
@@ -291,28 +237,12 @@ if __name__ == "__main__":
             print("No GPU found. Aborting.")
             sys.exit(0)
 
-        de = f'/device:GPU:{gpu_index}'
+        de = f"/device:GPU:{gpu_index}"
 
     with tf.device(de):
-        if dev == 'gpu':
-            nvidia_smi.nvmlInit()
-            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu_index)
-
-        if mode == 'training':
+        if mode == "training":
             training_benchmark(batch_size)
-        elif mode == 'inference':
+        elif mode == "inference":
             inference_benchmark(iteration_limit=args.iteration_limit)
-
         if args.test_mode:
-            print("Training GPU usage: 0")
-            print("Training GPU memory usage: 0")
-            print("Training Time: 0")
-            print("Training sample processing speed: 0")
-            print("In-sample inference GPU usage: 0")
-            print("In-sample inference GPU memory usage: 0")
-            print("In-sample inference time: 0")
-            print("In-sample sample processing speed: 0")
-            print("Out-of-Sample inference GPU usage: 0")
-            print("Out-of-Sample inference GPU memory usage: 0")
-            print("Out-of-Sample inference time: 0")
-            print("Out-of-Sample sample processing speed: 0")
+            print("total_time: 0.0\navg_time_per_sample: 0.0")

--- a/benchmarks/CIFAR_realtime_benchmark/CIFAR_realtime.py
+++ b/benchmarks/CIFAR_realtime_benchmark/CIFAR_realtime.py
@@ -198,7 +198,9 @@ def inference_benchmark(iteration_limit=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML CIFAR benchmark")
     parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
-    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument(
+        "mode", choices=["training", "inference", "test"], default="inference"
+    )
     parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
     parser.add_argument("-n", "--n_epochs_training", default=10, nargs="?", type=int)
     parser.add_argument("-t", "--test_mode", action="store_true")
@@ -244,5 +246,5 @@ if __name__ == "__main__":
             training_benchmark(batch_size)
         elif mode == "inference":
             inference_benchmark(iteration_limit=args.iteration_limit)
-        if args.test_mode:
+        elif mode == "test":
             print("total_time: 0.0\navg_time_per_sample: 0.0")

--- a/benchmarks/CIFAR_realtime_benchmark/benchmark.json
+++ b/benchmarks/CIFAR_realtime_benchmark/benchmark.json
@@ -10,41 +10,11 @@
   "setup_command": "./setup.sh",
   "run_command": "./CIFAR_realtime.py",
   "stats": {
-    "training_GPU_load": {
-      "regex": "Training GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
+    "total_time": {
+      "regex": "total_time: (\\d+(?:\\.\\d+))"
     },
-    "training_GPU_memory": {
-      "regex": "Training GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "training_time": {
-      "regex": "Training Time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "training_sample_processing_speed": {
-      "regex": "Training sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "insample_inference_GPU_load": {
-      "regex": "In-sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "insample_inference_GPU_memory": {
-      "regex": "In-sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "in_sample_inference_time": {
-      "regex": "In-sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "in_sample_inference_processing_speed": {
-      "regex": "In-sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_GPU_load": {
-      "regex": "Out-of-Sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_GPU_memory": {
-      "regex": "Out-of-Sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_inference_time": {
-      "regex": "Out-of-Sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_inference_processing_speed": {
-      "regex": "Out-of-Sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
+    "avg_time_per_sample": {
+      "regex": "avg_time_per_sample: (\\d+(?:\\.\\d+))"
     }
   },
   "virtualenv": true

--- a/benchmarks/CIFAR_realtime_benchmark/presets/test.json
+++ b/benchmarks/CIFAR_realtime_benchmark/presets/test.json
@@ -1,4 +1,3 @@
 {
-    "args": "cpu training --n_epochs_training 1 --test_mode"
+  "args": "cpu test --n_epochs_training 1"
 }
-  

--- a/benchmarks/CIFAR_realtime_benchmark/requirements.txt
+++ b/benchmarks/CIFAR_realtime_benchmark/requirements.txt
@@ -1,10 +1,2 @@
 tensorflow-gpu
-sklearn
-gputil
 numpy
-numba
-nvidia-ml-py3
-nvidia-smi
-parso
-tensorflow_datasets
-keras

--- a/benchmarks/MNIST_realtime_benchmark/MNIST_realtime.py
+++ b/benchmarks/MNIST_realtime_benchmark/MNIST_realtime.py
@@ -210,7 +210,9 @@ def inference_benchmark(iteration_limit=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML MNIST benchmark")
     parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
-    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument(
+        "mode", choices=["training", "inference", "test"], default="inference"
+    )
     parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
     parser.add_argument("-n", "--n_epochs_training", default=50, nargs="?", type=int)
     parser.add_argument("-t", "--test_mode", action="store_true")
@@ -256,5 +258,5 @@ if __name__ == "__main__":
             training_benchmark(batch_size)
         elif mode == "inference":
             inference_benchmark(iteration_limit=args.iteration_limit)
-        if args.test_mode:
+        elif mode == "test":
             print("total_time: 0.0\navg_time_per_sample: 0.0")

--- a/benchmarks/MNIST_realtime_benchmark/MNIST_realtime.py
+++ b/benchmarks/MNIST_realtime_benchmark/MNIST_realtime.py
@@ -15,70 +15,24 @@
 
 import time
 import sys
-from datetime import datetime
 import argparse
-try:
-    import nvidia_smi
-except ModuleNotFoundError:
-    print("nvidia-smi has not been found. GPU support is excluded.")
-    pass
-import GPUtil
+
 import tensorflow as tf
 import tensorflow_datasets as tfds
 import tensorflow.keras as keras
 import numpy as np
 
-"""
-Global variables definition
-"""
+# Global variables definition
 batch_size = 1
 n_epochs = 6
 n_epochs_training = 50
 n_of_class = 10
 N = 150
 teacher_size = 8
-gpu_performance_sampling_time = 1
-keep_running = True
-
-
-class GPUstatistics(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs load
-    """
-
-    def on_train_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_predict_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
 
 
 class TimeHistory(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs compute time
-    """
+    """A set of custom Keras callbacks to monitor Nvidia GPUs compute time."""
 
     def on_train_begin(self, logs={}):
         self.batch_times = []
@@ -124,30 +78,26 @@ class TimeHistory(keras.callbacks.Callback):
 
 
 def load_MNIST_data():
-    """
-    Loading and shaping the standard MNIST dataset
-    """
+    """Load and reshape the standard MNIST dataset."""
     (ds_train, ds_test), ds_info = tfds.load(
-        'mnist',
-        split=['train', 'test'],
+        "mnist",
+        split=["train", "test"],
         shuffle_files=True,
         as_supervised=True,
         with_info=True,
     )
 
     def normalize_img(image, label):
-        """Normalizes images: `uint8` -> `float32`."""
-        return tf.cast(image, tf.float32) / 255., label
+        """Normalize images: `uint8` -> `float32`."""
+        return tf.cast(image, tf.float32) / 255.0, label
 
-    ds_train = ds_train.map(
-        normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
+    ds_train = ds_train.map(normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
     ds_train = ds_train.cache()
-    ds_train = ds_train.shuffle(ds_info.splits['train'].num_examples)
+    ds_train = ds_train.shuffle(ds_info.splits["train"].num_examples)
     ds_train = ds_train.batch(128)
     ds_train = ds_train.prefetch(tf.data.AUTOTUNE)
 
-    ds_test = ds_test.map(
-        normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
+    ds_test = ds_test.map(normalize_img, num_parallel_calls=tf.data.AUTOTUNE)
     ds_test = ds_test.batch(128)
     ds_test = ds_test.cache()
     ds_test = ds_test.prefetch(tf.data.AUTOTUNE)
@@ -156,124 +106,120 @@ def load_MNIST_data():
 
 
 def create_MNIST_model():
-    model = tf.keras.models.Sequential([
-        tf.keras.layers.Flatten(input_shape=(28, 28)),
-        tf.keras.layers.Dense(128, activation='relu'),
-        tf.keras.layers.Dense(64, activation='relu'),
-        tf.keras.layers.Dense(32, activation='relu'),
-        tf.keras.layers.Dense(10, activation='softmax')
-    ])
+    model = keras.models.Sequential(
+        [
+            keras.layers.Flatten(input_shape=(28, 28)),
+            keras.layers.Dense(128, activation="relu"),
+            keras.layers.Dense(64, activation="relu"),
+            keras.layers.Dense(32, activation="relu"),
+            keras.layers.Dense(10, activation="softmax"),
+        ]
+    )
     model.compile(
-        optimizer=tf.keras.optimizers.Adam(0.001),
-        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
-        metrics=[tf.keras.metrics.SparseCategoricalAccuracy()],
+        optimizer=keras.optimizers.Adam(0.001),
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=[keras.metrics.SparseCategoricalAccuracy()],
     )
 
     return model
 
 
+def gen_stats_file_name(prefix):
+    """Generate stats file name with prefix."""
+    from time import strftime
+
+    return f'stats_file_{prefix}_{strftime("%Y-%m-%d_%H-%M-%S")}.txt'
+
+
 def training_benchmark(batch_size):
     """
-    Training benchmark evaluating number of training inputs processed per second
+    Perform training benchmark.
+
+    Evaluates number of training inputs processed per second.
     """
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_training"+dt_string+".txt", 'w')
-
     ds_train, _ = load_MNIST_data()
-
     model = create_MNIST_model()
 
     time_callback = TimeHistory()
-    model.fit(ds_train,
-              epochs=n_epochs_training,
-              callbacks=[time_callback],
-              batch_size=batch_size,
-              verbose=1)
+    model.fit(
+        ds_train,
+        epochs=n_epochs_training,
+        callbacks=[time_callback],
+        batch_size=batch_size,
+        verbose=1,
+    )
 
-    training_time = sum(time_callback.batch_times)  # total time
-    time_per_epoch = training_time / n_epochs_training
-    time_per_batch = time_per_epoch / (len(ds_train)//batch_size)  # time per batch
-    time_per_sample = time_per_epoch / len(ds_train)  # time per sample
-    training_sample_per_second = 1./time_per_sample  # sample per seconds
+    with open(gen_stats_file_name("training"), "w") as stats_file:
+        for batch_time in time_callback.batch_times:
+            stats_file.write(f"{batch_time}\n")
 
-    L = [str(training_time), ',', str(time_per_batch), ',', str(time_per_sample),
-         ',', str(training_sample_per_second)]
-    stats_file.writelines(L)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-    stats_file.close()
+    total_time = sum(time_callback.batch_times)
+
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / n_epochs_training / len(ds_train)}"
+    )
 
 
 def inference_benchmark(iteration_limit=None):
     """
-    Inference benchmark evaluating number of Out-of-Sample inputs processed per second
-    """
-    global keep_running
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_inference"+dt_string+".txt", 'w')
+    Perform inference benchmark.
 
+    Evaluates number of Out-of-Sample inputs processed per second.
+    """
     ds_train, ds_test = load_MNIST_data()
-
-    """
-    Training the model without measuring its performances to prepare for inference
-    """
     model = create_MNIST_model()
 
+    # Train the model without measuring its performance to prepare for inference
     model.fit(ds_train, epochs=n_epochs, verbose=0)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-
-    """
-    Performing inference on Out-of-Sample multiple times to obtain average performance
-    """
-    sample_count = 0
-    total_time = 0
-
+    # Perform inference on Out-of-Sample multiple times to obtain average performance
     n_iterations = 0
-
-    while(keep_running):
-        print(f"Iteration {n_iterations}")
-        L = []
-        for batch in ds_test:  # online prediction (one sample at time)
-            try:
-                for DS in batch[0]:
-                    DS = np.expand_dims(DS, 0)
-                    start_time = time.time()
-                    _ = model(DS)
-                    end_time = time.time() - start_time
-                    total_time += end_time
-                    sample_count += 1
-                    latency = total_time/sample_count
-                    throughput = sample_count/total_time
-                    L = [str(end_time), ',', str(sample_count), ',', str(
-                        latency), ',', str(throughput), ',', str(total_time)]
-                    stats_file.writelines(L)
-                    stats_file.writelines('\n')
-            except KeyboardInterrupt:
-                keep_running = False
-                break
-        n_iterations += 1
-        if iteration_limit:
-            if n_iterations+1 > iteration_limit:
+    keep_running = True
+    total_time = 0.0
+    with open(gen_stats_file_name("inference"), "w") as stats_file:
+        while keep_running:
+            print(f"Iteration {n_iterations}")
+            for batch in ds_test:  # online prediction (one sample at time)
+                try:
+                    for DS in batch[0]:
+                        DS = np.expand_dims(DS, 0)
+                        start_time = time.time()
+                        _ = model(DS)
+                        sample_time = time.time() - start_time
+                        total_time += sample_time
+                        stats_file.write(f"{sample_time}\n")
+                        stats_file.flush()
+                except KeyboardInterrupt:
+                    keep_running = False
+                    break
+            n_iterations += 1
+            if iteration_limit and n_iterations + 1 > iteration_limit:
                 break
 
-    print('INFERENCE COMPLETED!')
-    stats_file.close()
+    print("INFERENCE COMPLETED!")
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / (len(ds_test) * n_iterations)}"
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML MNIST benchmark")
-    parser.add_argument("device_type",
-                        choices=["gpu", "cpu"],
-                        default="gpu")
-    parser.add_argument("mode",
-                        choices=["training", "inference"],
-                        default="inference")
-    parser.add_argument("-g", "--gpu_index", default=0, nargs='?')
-    parser.add_argument("-n", "--n_epochs_training", default=50, nargs='?', type=int)
-    parser.add_argument("-t", "--test_mode", action='store_true')
-    parser.add_argument("-l", "--iteration_limit",
-                        help="Maximum number of inference iterations", type=int)
+    parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
+    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
+    parser.add_argument("-n", "--n_epochs_training", default=50, nargs="?", type=int)
+    parser.add_argument("-t", "--test_mode", action="store_true")
+    parser.add_argument(
+        "-l",
+        "--iteration_limit",
+        help="Maximum number of inference iterations",
+        type=int,
+    )
 
     args = parser.parse_args()
     dev = args.device_type
@@ -281,27 +227,20 @@ if __name__ == "__main__":
     gpu_index = args.gpu_index
     n_epochs_training = args.n_epochs_training
 
-    """
-    SET DEVICE
-    """
-    if dev == 'cpu':
-        de = '/cpu:0'
-    elif dev == 'gpu':
-        """
-        Checking GPU availability
-        """
-        if tf.config.list_physical_devices('GPU') == 0:
+    # SET DEVICE
+    if dev == "cpu":
+        de = "/cpu:0"
+    elif dev == "gpu":
+        # Check GPU availability
+        if tf.config.list_physical_devices("GPU") == 0:
             print("GPU unavailable. Aborting.")
             sys.exit(0)
 
-        """
-        Telling to the used GPU to automatically increase the amount of used memory
-        """
-        GPUs = GPUtil.getGPUs()
-        gpus = tf.config.list_physical_devices('GPU')
+        gpus = tf.config.list_physical_devices("GPU")
 
         if gpus:
-            if len(gpus) >= gpu_index+1:
+            if len(gpus) >= gpu_index + 1:
+                # Use dynamic GPU memory allocation
                 tf.config.experimental.set_memory_growth(gpus[gpu_index], True)
             else:
                 print(f"GPU {gpu_index} not found. Aborting.")
@@ -310,28 +249,12 @@ if __name__ == "__main__":
             print("No GPU found. Aborting.")
             sys.exit(0)
 
-        de = f'/device:GPU:{gpu_index}'
+        de = f"/device:GPU:{gpu_index}"
 
     with tf.device(de):
-        if dev == 'gpu':
-            nvidia_smi.nvmlInit()
-            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu_index)
-
-        if mode == 'training':
+        if mode == "training":
             training_benchmark(batch_size)
-        elif mode == 'inference':
+        elif mode == "inference":
             inference_benchmark(iteration_limit=args.iteration_limit)
-
         if args.test_mode:
-            print("Training GPU usage: 0")
-            print("Training GPU memory usage: 0")
-            print("Training Time: 0")
-            print("Training sample processing speed: 0")
-            print("In-sample inference GPU usage: 0")
-            print("In-sample inference GPU memory usage: 0")
-            print("In-sample inference time: 0")
-            print("In-sample sample processing speed: 0")
-            print("Out-of-Sample inference GPU usage: 0")
-            print("Out-of-Sample inference GPU memory usage: 0")
-            print("Out-of-Sample inference time: 0")
-            print("Out-of-Sample sample processing speed: 0")
+            print("total_time: 0.0\navg_time_per_sample: 0.0")

--- a/benchmarks/MNIST_realtime_benchmark/benchmark.json
+++ b/benchmarks/MNIST_realtime_benchmark/benchmark.json
@@ -10,41 +10,11 @@
   "setup_command": "./setup.sh",
   "run_command": "./MNIST_realtime.py",
   "stats": {
-    "training_GPU_load": {
-      "regex": "Training GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
+    "total_time": {
+      "regex": "total_time: (\\d+(?:\\.\\d+))"
     },
-    "training_GPU_memory": {
-      "regex": "Training GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "training_time": {
-      "regex": "Training Time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "training_sample_processing_speed": {
-      "regex": "Training sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "insample_inference_GPU_load": {
-      "regex": "In-sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "insample_inference_GPU_memory": {
-      "regex": "In-sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "in_sample_inference_time": {
-      "regex": "In-sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "in_sample_inference_processing_speed": {
-      "regex": "In-sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_GPU_load": {
-      "regex": "Out-of-Sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_GPU_memory": {
-      "regex": "Out-of-Sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_inference_time": {
-      "regex": "Out-of-Sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-    },
-    "out_of_sample_inference_processing_speed": {
-      "regex": "Out-of-Sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
+    "avg_time_per_sample": {
+      "regex": "avg_time_per_sample: (\\d+(?:\\.\\d+))"
     }
   },
   "virtualenv": true

--- a/benchmarks/MNIST_realtime_benchmark/presets/test.json
+++ b/benchmarks/MNIST_realtime_benchmark/presets/test.json
@@ -1,4 +1,3 @@
 {
-    "args": "cpu training --n_epochs_training 1 --test_mode"
+  "args": "cpu test --n_epochs_training 1"
 }
-  

--- a/benchmarks/MNIST_realtime_benchmark/requirements.txt
+++ b/benchmarks/MNIST_realtime_benchmark/requirements.txt
@@ -1,10 +1,3 @@
 tensorflow-gpu
-sklearn
-gputil
 numpy
-numba
-nvidia-ml-py3
-nvidia-smi
-parso
 tensorflow_datasets
-keras

--- a/benchmarks/TeacherStudent_realtime_benchmark/TeacherStudent_realtime.py
+++ b/benchmarks/TeacherStudent_realtime_benchmark/TeacherStudent_realtime.py
@@ -15,15 +15,9 @@
 
 import time
 import sys
-import numpy as np
-from datetime import datetime
 import argparse
-try:
-    import nvidia_smi
-except ModuleNotFoundError:
-    print("nvidia-smi has not been found. GPU support is excluded.")
-    pass
-import GPUtil
+
+import numpy as np
 import tensorflow as tf
 import tensorflow.keras as keras
 from tensorflow.keras import Sequential
@@ -31,57 +25,17 @@ from tensorflow.keras.layers import Dense
 from keras.utils.np_utils import to_categorical
 
 
-"""
-Global variables definition
-"""
+# Global variables definition
 batch_size = 1
 n_epochs = 1
 n_epochs_training = 200
 n_of_class = 10
 N = 150
 teacher_size = 8
-gpu_performance_sampling_time = 1
-keep_running = True
-
-
-class GPUstatistics(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs load
-    """
-
-    def on_train_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_begin(self, logs={}):
-        self.gpu_load = []
-        self.gpu_mem = []
-
-    def on_predict_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_predict_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_begin(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
-
-    def on_train_batch_end(self, batch, logs={}):
-        res = nvidia_smi.nvmlDeviceGetUtilizationRates(handle)
-        self.gpu_load.append(res.gpu)
-        self.gpu_mem.append(res.memory)
 
 
 class TimeHistory(keras.callbacks.Callback):
-    """
-    A set of custom Keras callbacks to monitor Nvidia GPUs compute time
-    """
+    """A set of custom Keras callbacks to monitor Nvidia GPUs compute time."""
 
     def on_train_begin(self, logs={}):
         self.batch_times = []
@@ -127,28 +81,28 @@ class TimeHistory(keras.callbacks.Callback):
 
 
 def generate_data(input_shape_X, N, n_of_class):
-    '''
-    Teacher definition
-    '''
-    initializer = tf.keras.initializers.RandomNormal(mean=0., stddev=1.)
-    teacher = Sequential()
-    teacher.add(Dense(teacher_size, activation='sigmoid',
-                      kernel_initializer=initializer,
-                      input_shape=(input_shape_X,)))
-    teacher.add(Dense(n_of_class,
-                      activation='softmax'))
-    '''
-    Random Data generation
-    '''
+    # Teacher definition
+    initializer = keras.initializers.RandomNormal(mean=0.0, stddev=1.0)
+    teacher = keras.Sequential()
+    teacher.add(
+        Dense(
+            teacher_size,
+            activation="sigmoid",
+            kernel_initializer=initializer,
+            input_shape=(input_shape_X,),
+        )
+    )
+    teacher.add(Dense(n_of_class, activation="softmax"))
+    # Random Data generation
     data = tf.random.normal((N, input_shape_X), 0, 1)
     labels = teacher.predict(data).argmax(1)
     labels = tf.convert_to_tensor(labels)
 
     labels = to_categorical(labels, num_classes=n_of_class)
-    x_train = data[:int(N*9/10)]
-    x_test = data[int(N*9/10):]
-    y_train = labels[:int(N*9/10)]
-    y_test = labels[int(N*9/10):]
+    x_train = data[: int(N * 9 / 10)]
+    x_test = data[int(N * 9 / 10) :]
+    y_train = labels[: int(N * 9 / 10)]
+    y_test = labels[int(N * 9 / 10) :]
     return (x_train, y_train), (x_test, y_test)
 
 
@@ -156,12 +110,10 @@ def create_model(input_shape_X):
     model = Sequential()
 
     if net_size == 0:
-        model.add(Dense(n_of_class,
-                        activation='softmax',
-                        input_shape=(input_shape_X,)))
+        model.add(Dense(n_of_class, activation="softmax", input_shape=(input_shape_X,)))
     else:
-        model.add(Dense(net_size, activation='sigmoid', input_shape=(input_shape_X,)))
-        model.add(Dense(n_of_class, activation='softmax'))
+        model.add(Dense(net_size, activation="sigmoid", input_shape=(input_shape_X,)))
+        model.add(Dense(n_of_class, activation="softmax"))
 
     loss = keras.losses.CategoricalCrossentropy()
     optim = keras.optimizers.SGD(learning_rate=0.01, momentum=0.05)
@@ -171,105 +123,104 @@ def create_model(input_shape_X):
     return model
 
 
+def gen_stats_file_name(prefix):
+    """Generate stats file name with prefix."""
+    from time import strftime
+
+    return f'stats_file_{prefix}_{strftime("%Y-%m-%d_%H-%M-%S")}.txt'
+
+
 def training_benchmark(input_shape_X, batch_size, n_of_class):
     """
-    Training benchmark evaluating number of inputs processed per second
+    Perform training benchmark.
+
+    Evaluates number of training inputs processed per second.
     """
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_training"+dt_string+".txt", 'w')
-
     (X_train, Y_train), (_, _) = generate_data(input_shape_X, N, n_of_class)
-
     model = create_model(input_shape_X=input_shape_X)
 
     time_callback = TimeHistory()
-    model.fit(X_train, Y_train, epochs=n_epochs_training, batch_size=batch_size,
-              callbacks=[time_callback],
-              verbose=1)
+    model.fit(
+        X_train,
+        Y_train,
+        epochs=n_epochs_training,
+        batch_size=batch_size,
+        callbacks=[time_callback],
+        verbose=1,
+    )
 
-    training_time = sum(time_callback.batch_times)  # total time
-    time_per_epoch = training_time / n_epochs_training
-    time_per_batch = time_per_epoch / (len(X_train)//batch_size)  # time per batch
-    time_per_sample = time_per_epoch / len(X_train)  # time per sample
-    training_sample_per_second = 1./time_per_sample  # sample per seconds
+    with open(gen_stats_file_name("training"), "w") as stats_file:
+        for batch_time in time_callback.batch_times:
+            stats_file.write(f"{batch_time}\n")
 
-    L = [str(training_time), ',', str(time_per_batch), ',', str(time_per_sample),
-         ',', str(training_sample_per_second)]
-    stats_file.writelines(L)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-    stats_file.close()
+    total_time = sum(time_callback.batch_times)
+
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / n_epochs_training / len(X_train)}"
+    )
 
 
 def inference_benchmark(input_shape_X, batch_size, n_of_class, iteration_limit=None):
-    global keep_running
-    dt_string = datetime.now().strftime("%d_%m_%Y_%H_%M_%S")
-    stats_file = open("stats_file_inference"+dt_string+".txt", 'w')
+    """
+    Perform inference benchmark.
 
+    Evaluates number of Out-of-Sample inputs processed per second.
+    """
     (X_train, Y_train), (X_test, _) = generate_data(input_shape_X, N, n_of_class)
-
-    """
-    Training the model without measuring its performances to prepare for inference
-    """
     model = create_model(input_shape_X=input_shape_X)
 
+    # Train the model without measuring its performance to prepare for inference
     model.fit(X_train, Y_train, epochs=n_epochs, batch_size=batch_size, verbose=0)
+    print("TRAINING COMPLETED!")
 
-    print('TRAINING COMPLETED!')
-
-    """
-    Performing inference on Out-of-Sample multiple times to obtain average performance
-    """
-    sample_count = 0
-    total_time = 0
-
+    # Perform inference on Out-of-Sample multiple times to obtain average performance
     n_iterations = 0
-
-    while(keep_running):
-        print(f"Iteration {n_iterations}")
-        L = []
-        for X in X_test:  # online prediction (one sample at time)
+    total_time = 0.0
+    keep_running = True
+    with open(gen_stats_file_name("inference"), "w") as stats_file:
+        while keep_running:
+            print(f"Iteration {n_iterations}")
             try:
-                X = np.expand_dims(X, 0)
-                start_time = time.time()
-                _ = model(X)
-                end_time = time.time() - start_time
-                total_time += end_time
-                sample_count += 1
-                latency = total_time/sample_count
-                throughput = sample_count/total_time
-                L = [str(end_time), ',', str(sample_count), ',', str(
-                    latency), ',', str(throughput), ',', str(total_time)]
-                stats_file.writelines(L)
-                stats_file.writelines('\n')
+                for X in X_test:
+                    X = np.expand_dims(X, 0)
+                    start_time = time.time()
+                    _ = model(X)
+                    sample_time = time.time() - start_time
+                    total_time += sample_time
+                    stats_file.write(f"{sample_time}\n")
+                    stats_file.flush()
             except KeyboardInterrupt:
                 keep_running = False
                 break
-        n_iterations += 1
-        if iteration_limit:
-            if n_iterations+1 > iteration_limit:
+            n_iterations += 1
+            if iteration_limit and n_iterations + 1 > iteration_limit:
                 break
 
-    print('INFERENCE COMPLETED!')
-
-    stats_file.close()
+    print("INFERENCE COMPLETED!")
+    print(
+        f"total_time: {total_time}\n"
+        f"avg_time_per_sample: {total_time / (len(X_test) * n_iterations)}"
+    )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML Teacher-Student benchmark")
-    parser.add_argument("device_type",
-                        choices=["gpu", "cpu"],
-                        default="gpu")
-    parser.add_argument("mode",
-                        choices=["training", "inference"],
-                        default="inference")
-    parser.add_argument("-g", "--gpu_index", default=0, nargs='?')
-    parser.add_argument("-s", "--net_size", default=2000, nargs='?')
-    parser.add_argument("-n", "--n_epochs_training", default=200, nargs='?', type=int)
-    parser.add_argument("-i", "--input_shape_X", default=20000, nargs='?')
-    parser.add_argument("-t", "--test_mode", action='store_true')
-    parser.add_argument("-l", "--iteration_limit",
-                        help="Maximum number of inference iterations", type=int)
+    parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
+    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
+    parser.add_argument("-s", "--net_size", default=2000, nargs="?")
+    parser.add_argument("-n", "--n_epochs_training", default=200, nargs="?", type=int)
+    parser.add_argument("-i", "--input_shape_X", default=20000, nargs="?")
+    parser.add_argument("-t", "--test_mode", action="store_true")
+    parser.add_argument(
+        "-l",
+        "--iteration_limit",
+        help="Maximum number of inference iterations",
+        type=int,
+    )
 
     args = parser.parse_args()
     dev = args.device_type
@@ -279,27 +230,20 @@ if __name__ == "__main__":
     input_shape_X = args.input_shape_X
     n_epochs_training = args.n_epochs_training
 
-    """
-    SET DEVICE
-    """
-    if dev == 'cpu':
-        de = '/cpu:0'
-    elif dev == 'gpu':
-        """
-        Checking GPU availability
-        """
-        if tf.config.list_physical_devices('GPU') == 0:
+    # SET DEVICE
+    if dev == "cpu":
+        de = "/cpu:0"
+    elif dev == "gpu":
+        # Check GPU availability
+        if tf.config.list_physical_devices("GPU") == 0:
             print("GPU unavailable. Aborting.")
             sys.exit(0)
 
-        """
-        Telling to the used GPU to automatically increase the amount of used memory
-        """
-        GPUs = GPUtil.getGPUs()
-        gpus = tf.config.list_physical_devices('GPU')
+        gpus = tf.config.list_physical_devices("GPU")
 
         if gpus:
-            if len(gpus) >= gpu_index+1:
+            if len(gpus) >= gpu_index + 1:
+                # Use dynamic GPU memory allocation
                 tf.config.experimental.set_memory_growth(gpus[gpu_index], True)
             else:
                 print(f"GPU {gpu_index} not found. Aborting.")
@@ -308,29 +252,17 @@ if __name__ == "__main__":
             print("No GPU found. Aborting.")
             sys.exit(0)
 
-        de = f'/device:GPU:{gpu_index}'
+        de = f"/device:GPU:{gpu_index}"
 
     with tf.device(de):
-        if dev == 'gpu':
-            nvidia_smi.nvmlInit()
-            handle = nvidia_smi.nvmlDeviceGetHandleByIndex(gpu_index)
-
-        if mode == 'training':
+        if mode == "training":
             training_benchmark(input_shape_X, batch_size, n_of_class)
-        elif mode == 'inference':
-            inference_benchmark(input_shape_X, batch_size,
-                                n_of_class, iteration_limit=args.iteration_limit)
-
-        if args.test_mode:
-            print("Training GPU usage: 0")
-            print("Training GPU memory usage: 0")
-            print("Training Time: 0")
-            print("Training sample processing speed: 0")
-            print("In-sample inference GPU usage: 0")
-            print("In-sample inference GPU memory usage: 0")
-            print("In-sample inference time: 0")
-            print("In-sample sample processing speed: 0")
-            print("Out-of-Sample inference GPU usage: 0")
-            print("Out-of-Sample inference GPU memory usage: 0")
-            print("Out-of-Sample inference time: 0")
-            print("Out-of-Sample sample processing speed: 0")
+        elif mode == "inference":
+            inference_benchmark(
+                input_shape_X,
+                batch_size,
+                n_of_class,
+                iteration_limit=args.iteration_limit,
+            )
+        elif mode == "test":
+            print("total_time: 0.0\navg_time_per_sample: 0.0")

--- a/benchmarks/TeacherStudent_realtime_benchmark/TeacherStudent_realtime.py
+++ b/benchmarks/TeacherStudent_realtime_benchmark/TeacherStudent_realtime.py
@@ -209,7 +209,9 @@ def inference_benchmark(input_shape_X, batch_size, n_of_class, iteration_limit=N
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A ML Teacher-Student benchmark")
     parser.add_argument("device_type", choices=["gpu", "cpu"], default="gpu")
-    parser.add_argument("mode", choices=["training", "inference"], default="inference")
+    parser.add_argument(
+        "mode", choices=["training", "inference", "test"], default="inference"
+    )
     parser.add_argument("-g", "--gpu_index", default=0, nargs="?")
     parser.add_argument("-s", "--net_size", default=2000, nargs="?")
     parser.add_argument("-n", "--n_epochs_training", default=200, nargs="?", type=int)

--- a/benchmarks/TeacherStudent_realtime_benchmark/benchmark.json
+++ b/benchmarks/TeacherStudent_realtime_benchmark/benchmark.json
@@ -1,48 +1,21 @@
 {
-    "name": "Realtime Teacher-Student benchmark",
-    "description": "Training and inference using Teacher-Student pattern",
-    "default_preset": "inference",
-    "test_command": ["pip install flake8", "flake8 --exclude .venv"],
-    "test_preset": "test",
-    "setup_command": "./setup.sh",
-    "run_command": "./TeacherStudent_realtime.py",
-    "stats": {
-        "training_GPU_load":{
-            "regex": "Training GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "training_GPU_memory":{
-            "regex": "Training GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "training_time":{
-            "regex": "Training Time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "training_sample_processing_speed":{
-            "regex": "Training sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "insample_inference_GPU_load":{
-            "regex": "In-sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "insample_inference_GPU_memory":{
-            "regex": "In-sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "in_sample_inference_time":{
-            "regex": "In-sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "in_sample_inference_processing_speed":{
-            "regex": "In-sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "out_of_sample_GPU_load":{
-            "regex": "Out-of-Sample inference GPU usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "out_of_sample_GPU_memory":{
-            "regex": "Out-of-Sample inference GPU memory usage: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "out_of_sample_inference_time":{
-            "regex": "Out-of-Sample inference time: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        },
-        "out_of_sample_inference_processing_speed":{
-            "regex": "Out-of-Sample sample processing speed: [+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)"
-        }
+  "name": "Realtime Teacher-Student benchmark",
+  "description": "Training and inference using Teacher-Student pattern",
+  "default_preset": "inference",
+  "test_command": [
+    "pip install flake8",
+    "flake8 --exclude .venv"
+  ],
+  "test_preset": "test",
+  "setup_command": "./setup.sh",
+  "run_command": "./TeacherStudent_realtime.py",
+  "stats": {
+    "total_time": {
+      "regex": "total_time: (\\d+(?:\\.\\d+))"
     },
-    "virtualenv": true   
- }
+    "avg_time_per_sample": {
+      "regex": "avg_time_per_sample: (\\d+(?:\\.\\d+))"
+    }
+  },
+  "virtualenv": true
+}

--- a/benchmarks/TeacherStudent_realtime_benchmark/presets/test.json
+++ b/benchmarks/TeacherStudent_realtime_benchmark/presets/test.json
@@ -1,4 +1,3 @@
 {
-    "args": "cpu training --n_epochs_training 1 --test_mode"
+  "args": "cpu test --n_epochs_training 1"
 }
-  

--- a/benchmarks/TeacherStudent_realtime_benchmark/requirements.txt
+++ b/benchmarks/TeacherStudent_realtime_benchmark/requirements.txt
@@ -1,10 +1,3 @@
 tensorflow-gpu
-sklearn
-gputil
 numpy
-numba
-nvidia-ml-py3
-nvidia-smi
-parso
-tensorflow_datasets
 keras


### PR DESCRIPTION
This PR removes unused stats in realtime benchmarks and ensures that they
output all of them in every preset, so that no warning is issued by
`o4bc-bench`.

Closes #192
