### PR TITLE
Ellipsize spinner text when too long

### DIFF
--- a/openforbc_benchmark/cli/benchmark.py
+++ b/openforbc_benchmark/cli/benchmark.py
@@ -106,8 +106,14 @@ class CliBenchmarkRun:
         for preset, tasks in self.benchmark_run.run():
             self._log(f'Running "{benchmark_id}" preset "{preset.name}"')
             for i, task in enumerate(tasks):
-                self.spinner.text = (
-                    f"{benchmark_id}(run:{preset.name}): {argv_join(task.args)}"
+                from os import get_terminal_size
+                from textwrap import shorten
+
+                self.spinner.text = shorten(
+                    f"{benchmark_id}(run:{preset.name}): {argv_join(task.args)}",
+                    # spinner uses 2 chars
+                    (get_terminal_size().columns if stdout.isatty() else 80) - 2,
+                    placeholder="...",
                 )
                 self._run_task_or_err(
                     task,


### PR DESCRIPTION
This prevents the spinner text from overflowing into the history.

## Pictures

Old behaviour:
<img width="722" alt="Screenshot 2022-04-06 at 19 19 14" src="https://user-images.githubusercontent.com/8156877/162032011-500efb5c-1179-403a-945d-beb6ff9a073d.png">

With this PR applied:
<img width="722" alt="Screenshot 2022-04-06 at 19 20 29" src="https://user-images.githubusercontent.com/8156877/162032069-822f699a-5420-4cd0-8fc6-b776cbcc7554.png">

