### PR TITLE
Fix sklearn requirement

### DIFF
--- a/benchmarks/MNIST_FCNeuralNetwork/requirements.txt
+++ b/benchmarks/MNIST_FCNeuralNetwork/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow-gpu
 matplotlib
-sklearn
+scikit-learn

--- a/benchmarks/tensorflow_benchmark/requirements.txt
+++ b/benchmarks/tensorflow_benchmark/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow>2
-sklearn
+scikit-learn
 pandas
 numpy


### PR DESCRIPTION
Replace `sklearn` with `scikit-learn` in benchmarks' requirements