### PR TITLE
Disable phoronix benchmarks in tests

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,6 +66,8 @@ jobs:
         run: |
           for benchmark in $(ls benchmarks); do
             [ -f benchmarks/$benchmark/benchmark.json ] || continue
+            [[ "$benchmark" == phoronix* ]] && continue
+            [[ "$benchmark" == unigine* ]] && continue
 
             echo "::group::$benchmark"
             echo "Running benchmark's tests"


### PR DESCRIPTION
Will later try to find out a way to make gpu benchmarks run in CI, but as of now it's not possible...