### PR TITLE
Fix tensorflow dependency after TF-gpu removal

### DIFF
--- a/benchmarks/MNIST_FCNeuralNetwork/requirements.txt
+++ b/benchmarks/MNIST_FCNeuralNetwork/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow-gpu
+tensorflow
 matplotlib
 scikit-learn

--- a/benchmarks/matmul_benchmark/requirements.txt
+++ b/benchmarks/matmul_benchmark/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-tensorflow-gpu
+tensorflow


### PR DESCRIPTION
`tensorflow-gpu` has been removed and replaced by plain `tensor flow` package.